### PR TITLE
fix(typeahead): add id to input, spread rest of props to downshift

### DIFF
--- a/components/Typeahead/Typeahead.js
+++ b/components/Typeahead/Typeahead.js
@@ -17,10 +17,14 @@ export default class Typeahead extends Component {
   itemToString = item => (item ? item.label : '');
 
   render() {
-    const { items, placeholder } = this.props;
+    const { items, placeholder, id, ...other } = this.props;
 
     return (
-      <Downshift onChange={this.handleChange} itemToString={this.itemToString}>
+      <Downshift
+        onChange={this.handleChange}
+        itemToString={this.itemToString}
+        {...other}
+      >
         {({
           getInputProps,
           getItemProps,
@@ -46,7 +50,10 @@ export default class Typeahead extends Component {
               <div className="bx--typeahead bx--form-item">
                 <input
                   className="bx--typeahead__input bx--text-input"
-                  {...getInputProps({ placeholder })}
+                  {...getInputProps({
+                    placeholder,
+                    id,
+                  })}
                 />
                 {inputValue && (
                   <button

--- a/components/Typeahead/Typeahead.story.js
+++ b/components/Typeahead/Typeahead.story.js
@@ -34,5 +34,5 @@ const onChange = evt => {
 };
 
 storiesOf('Typeahead', module).addWithInfo('Default', `Typeahead`, () => (
-  <Typeahead onChange={onChange} items={items} />
+  <Typeahead id="test" onChange={onChange} items={items} />
 ));


### PR DESCRIPTION
The spread to downshift isn't doing a tremendous amount right now, but will be used in the future. `id` is being plucked out and added to the input element itself