### PR TITLE
fix(props): allow passing in downshift props

### DIFF
--- a/components/Typeahead/Typeahead.js
+++ b/components/Typeahead/Typeahead.js
@@ -5,7 +5,6 @@ import Downshift from 'downshift';
 
 export default class Typeahead extends Component {
   static defaultProps = {
-    isOpen: false,
     placeholder: 'Filter...',
     onChange: () => {},
   };
@@ -17,10 +16,14 @@ export default class Typeahead extends Component {
   itemToString = item => (item ? item.label : '');
 
   render() {
-    const { items, placeholder, disabled, id } = this.props;
+    const { items, placeholder, disabled, id, ...other } = this.props;
 
     return (
-      <Downshift onChange={this.handleChange} itemToString={this.itemToString}>
+      <Downshift
+        onChange={this.handleChange}
+        itemToString={this.itemToString}
+        {...other}
+      >
         {({
           getInputProps,
           getItemProps,

--- a/components/Typeahead/Typeahead.story.js
+++ b/components/Typeahead/Typeahead.story.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from 'carbon-components-react';
 import { storiesOf, action } from '@storybook/react';
 import Typeahead from './Typeahead';
 

--- a/components/Typeahead/Typeahead.story.js
+++ b/components/Typeahead/Typeahead.story.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'carbon-components-react';
 import { storiesOf, action } from '@storybook/react';
 import Typeahead from './Typeahead';
 
@@ -33,6 +34,18 @@ const onChange = evt => {
   console.log(evt);
 };
 
-storiesOf('Typeahead', module).addWithInfo('Default', `Typeahead`, () => (
-  <Typeahead id="test" onChange={onChange} items={items} />
-));
+storiesOf('Typeahead', module)
+  .addWithInfo('Default', `Typeahead`, () => (
+    <Typeahead id="test" onChange={onChange} items={items} />
+  ))
+  .addWithInfo('Pre-selected', `Typeahead`, () => (
+    <Typeahead
+      id="test"
+      selectedItem={{
+        label: 'Banana',
+        value: 'banana',
+      }}
+      onChange={onChange}
+      items={items}
+    />
+  ));


### PR DESCRIPTION
Allows a user to pass in `selectedItem` to pre-select... an item.

Also fixes the spreading of props to do `downshift`, thereby enabling `selectedItem` or any other `downshift` prop