### PR TITLE
fix(components): update scss for Typeahead,  resolves #16

### DIFF
--- a/components/Typeahead/_typeahead.scss
+++ b/components/Typeahead/_typeahead.scss
@@ -1,6 +1,9 @@
 @import 'carbon-components/scss/globals/scss/colors';
+@import 'carbon-components/scss/globals/scss/layer';
+@import 'carbon-components/scss/globals/scss/helper-mixins';
 @import 'carbon-components/scss/globals/scss/import-once';
 @import 'carbon-components/scss/globals/scss/css--helpers';
+@import 'carbon-components/scss/globals/scss/css--reset';
 @import 'carbon-components/scss/globals/scss/vars';
 
 @include exports('typeahead') {
@@ -33,7 +36,7 @@
   }
 
   .bx--typeahead-menu {
-    @include button-reset(false);
+    @include button-reset;
     position: absolute;
     top: 0;
     right: 0;
@@ -75,7 +78,7 @@
   }
 
   .bx--typeahead-clear {
-    @include button-reset(false);
+    @include button-reset;
     position: absolute;
     top: 0;
     right: rem(45px);
@@ -111,6 +114,7 @@
 
   .bx--typeahead-items--expanded {
     height: auto;
+    z-index: 100;
   }
 
   .bx--typeahead__item {


### PR DESCRIPTION
Resolve error when compiling scss and change z-index of pull down to prevent overlap with elements below it.