### PR TITLE
fix(typeahead): a11y issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
   email: false
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH=$HOME/.yarn/bin:$PATH
 
 after_success:

--- a/components/Typeahead/Typeahead.js
+++ b/components/Typeahead/Typeahead.js
@@ -88,6 +88,8 @@ export default class Typeahead extends Component {
                 <input
                   className="bx--typeahead__input bx--text-input"
                   {...getInputProps({
+                    'aria-autocomplete': "list",
+                    'aria-expanded': isOpen,
                     disabled,
                     id,
                     placeholder,
@@ -118,6 +120,7 @@ export default class Typeahead extends Component {
     const iconMenuClass = classNames({
       'bx--typeahead-menu-icon': true,
       'bx--typeahead-menu-icon--active': isOpen,
+      'bx--typeahead-menu-icon--disabled': this.props.disabled
     });
 
     return (
@@ -146,13 +149,19 @@ export default class Typeahead extends Component {
     if (!inputValue) {
       return null;
     }
+
+    const iconClearClass = classNames({
+      'bx--typeahead-clear-icon': true,
+      'bx--typeahead-clear-icon--disabled': this.props.disabled
+    });
     return (
       <button
+        aria-label="clear selection"
         onClick={clearSelection}
         className="bx--typeahead-clear"
         disabled={this.props.disabled}>
         <svg
-          className="bx--typeahead-clear-icon"
+          className={iconClearClass}
           width="16"
           height="16"
           viewBox="0 0 16 16"

--- a/components/Typeahead/_typeahead.scss
+++ b/components/Typeahead/_typeahead.scss
@@ -70,6 +70,10 @@
     transform: rotate(180deg);
   }
 
+  .bx--typeahead-menu-icon--disabled {
+    fill: $ui-04;
+  }
+
   .bx--typeahead-menu-icon, .bx--typeahead-clear-icon {
     height: 100%;
   }
@@ -95,6 +99,10 @@
 
   .bx--typeahead-clear-icon {
     fill: $ui-05;
+  }
+
+  .bx--typeahead-clear-icon--disabled {
+    fill: $ui-04;
   }
 
   .bx--typeahead-items {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "build-storybook": "build-storybook",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "semantic-release":
-      "semantic-release pre && npm publish && semantic-release post"
+      "semantic-release pre && npm publish && semantic-release post",
+    "test": ""
   },
   "files": ["cjs/**/*", "es/**/*", "scss/**/*"],
   "eslintConfig": {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-react#

disabled clear selection button in a lighter shade, added aria labels for the input field
https://github.ibm.com/IAM/access-management/issues/4181
https://github.ibm.com/IAM/access-management/issues/4167

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
